### PR TITLE
Added step to start the tour after installing it.

### DIFF
--- a/README
+++ b/README
@@ -4,6 +4,12 @@ To install the tour locally, first install Go, then run:
 
 	$ go get golang.org/x/tour/gotour
 
+Then start the tour by executing:
+
+	$ $GOPATH/bin/gotour
+
+A web browser should open, starting the tour.
+
 Unless otherwise noted, the go-tour source files are distributed
 under the BSD-style license found in the LICENSE file.
 


### PR DESCRIPTION
The instructions for installing the go tour show how to install it, but not to start it.  I added the command to start the tour.