### PR TITLE
Change word count exercise to display the correct "fox" sentence

### DIFF
--- a/wc/wc.go
+++ b/wc/wc.go
@@ -36,8 +36,8 @@ var testCases = []struct {
 	{"I am learning Go!", map[string]int{
 		"I": 1, "am": 1, "learning": 1, "Go!": 1,
 	}},
-	{"The quick brown fox jumped over the lazy dog.", map[string]int{
-		"The": 1, "quick": 1, "brown": 1, "fox": 1, "jumped": 1,
+	{"The quick brown fox jumps over the lazy dog.", map[string]int{
+		"The": 1, "quick": 1, "brown": 1, "fox": 1, "jumps": 1,
 		"over": 1, "the": 1, "lazy": 1, "dog.": 1,
 	}},
 	{"I ate a donut. Then I ate another donut.", map[string]int{


### PR DESCRIPTION
The intention of this sentence is to use every letter of the alphabet. By using "jumped" instead of "jumps" you are missing the s.

Although this is not the intention of the exercise, this caught my eye.