### PR TITLE
improve example

### DIFF
--- a/content/methods.article
+++ b/content/methods.article
@@ -208,7 +208,7 @@ An empty interface may hold values of any type.
 (Every type implements at least zero methods.)
 
 Empty interfaces are used by code that handles values of unknown type.
-For example, `fmt.Print` takes any number of arguments of type `interface{}`.
+For example, `fmt.Println` takes any number of arguments of type `interface{}`.
 
 .play methods/empty-interface.go
 


### PR DESCRIPTION
Context: /methods/14

`fmt.Print` does not appear in the current and previous pages.
On the other hand, `fmt.Println` appears lots of times.
So IMHO this would be better for learners.