### PR TITLE
Fix a slice->array typo in moretypes.article

### DIFF
--- a/content/moretypes.article
+++ b/content/moretypes.article
@@ -138,7 +138,7 @@ then builds a slice that references it:
 
 When slicing, you may omit the high or low bounds to use their defaults instead.
 
-The default is zero for the low bound and the length of the slice for the high bound.
+The default is zero for the low bound and the length of the array for the high bound.
 
 For the array
 


### PR DESCRIPTION
As explained in https://github.com/golang/tour/issues/449, the tour's section on Slice defaults might have a typo in speaking about "length of the slice" instead of a "length of the array". This change is the proposed correction.