### PR TITLE
Update the "Exercise: Readers" instructions for clarity

### DIFF
--- a/content/methods.article
+++ b/content/methods.article
@@ -361,8 +361,8 @@ and consumes its output 8 bytes at a time.
 
 * Exercise: Readers
 
-Implement a `Reader` type that emits an infinite stream of the ASCII character
-`'A'`.
+Implement a `Reader` type, that emits an infinite stream of the ASCII character
+`'A'` to the supplied buffer `[]byte`.   
 
 .play methods/exercise-reader.go
 


### PR DESCRIPTION
For the intended audience of people new to the Go ecosystem, this statement
>Implement a `Reader` type, that emits an infinite stream of the ASCII character `'A'`

 is ambiguous considering the previous lesson referred to the concept in different terms by saying
>Read populates the given byte slice with data 

by adding
> to the supplied buffer `[]byte`

it clarifies what they should be interacting with to "emit an infinite stream"