### PR TITLE
tour: fixes typo in flowcontrol.article

### DIFF
--- a/content/flowcontrol.article
+++ b/content/flowcontrol.article
@@ -66,7 +66,7 @@ Variables declared by the statement are only in scope until the end of the `if`.
 Variables declared inside an `if` short statement are also available inside any
 of the `else` blocks.
 
-(Both calls to `pow` are executed and return before the call to `fmt.Println`
+(Both calls to `pow` are executed and returned before the call to `fmt.Println`
 in `main` begins.)
 
 .play flowcontrol/if-and-else.go


### PR DESCRIPTION
s/return/returned/

Consider a larger change:

`(Both calls to pow execute and return before the call to fmt.Println in main begins.)`