### PR TITLE
content: fix grammar in flowcontrol.article

### DIFF
--- a/content/flowcontrol.article
+++ b/content/flowcontrol.article
@@ -66,7 +66,7 @@ Variables declared by the statement are only in scope until the end of the `if`.
 Variables declared inside an `if` short statement are also available inside any
 of the `else` blocks.
 
-(Both calls to `pow` are executed and return before the call to `fmt.Println`
+(Both calls to `pow` execute and return before the call to `fmt.Println`
 in `main` begins.)
 
 .play flowcontrol/if-and-else.go

--- a/content/flowcontrol.article
+++ b/content/flowcontrol.article
@@ -66,7 +66,7 @@ Variables declared by the statement are only in scope until the end of the `if`.
 Variables declared inside an `if` short statement are also available inside any
 of the `else` blocks.
 
-(Both calls to `pow` execute and return before the call to `fmt.Println`
+(Both calls to `pow` return their results before the call to `fmt.Println`
 in `main` begins.)
 
 .play flowcontrol/if-and-else.go


### PR DESCRIPTION
The lack of agreement in tense between the parallel verbs `execute` (_are executed_) and `return` in this sentence threw me. This simpler construction is more grammatically correct, according to some standards, and less confusing to me.