### PR TITLE
tour: update Spanish tour link

### DIFF
--- a/content/welcome.article
+++ b/content/welcome.article
@@ -61,7 +61,7 @@ The tour is available in other languages:
 - [[https://go-tour-kr.appspot.com/][Korean — 한국어]]
 - [[https://go-tour-ro.appspot.com/][Romanian — Română]]
 - [[https://go-tour-ru-ru.appspot.com/][Russian - Русский]]
-- [[https://go-tour-es.appspot.com/][Spanish — Español]]
+- [[https://gotour-es.appspot.com/][Spanish — Español]]
 - [[https://go-tour-th.appspot.com/][Thai - ภาษาไทย]]
 - [[https://go-tour-turkish.appspot.com/][Turkish - Türkçe]]
 - [[https://go-tour-ua.appspot.com/][Ukrainian — Українська]]


### PR DESCRIPTION
Currently, go-tour-es.appspot.com is a 404, but the correct link
for Spanish tutorial can be seen at gotour-es.appspot.com.