### PR TITLE
content: swap points in `range continued` section

### DIFF
--- a/content/moretypes.article
+++ b/content/moretypes.article
@@ -245,14 +245,14 @@ The first is the index, and the second is a copy of the element at that index.
 
 * Range continued
 
+If you only want the index, you can omit the second variable.
+
+    for i := range pow
+
 You can skip the index or value by assigning to `_`.
 
     for i, _ := range pow
     for _, value := range pow
-
-If you only want the index, you can omit the second variable.
-
-    for i := range pow
 
 .play moretypes/range-continued.go
 


### PR DESCRIPTION
While reading, the points don't align with the code section. I think this might make sense, for first-time readers - as it directly correlates with what the specified example code is doing.