### PR TITLE
slice default high bound is the length of the array

### DIFF
--- a/content/moretypes.article
+++ b/content/moretypes.article
@@ -138,7 +138,7 @@ then builds a slice that references it:
 
 When slicing, you may omit the high or low bounds to use their defaults instead.
 
-The default is zero for the low bound and the length of the slice for the high bound.
+The default is zero for the low bound and the length of the array for the high bound.
 
 For the array
 


### PR DESCRIPTION
Taking to golang tour, in the "slice defaults" section, I saw that the slice's default high bound is defined as being the length of the slice, not the length of the array, which made more sense given the example shown in that section. 

In the moretypes.article file, line 141 was modified by replacing "slice" with "array".
