### PR TITLE
the default slice high bound is the length of the array, not the length of the slice

### DIFF
--- a/content/moretypes.article
+++ b/content/moretypes.article
@@ -138,7 +138,7 @@ then builds a slice that references it:
 
 When slicing, you may omit the high or low bounds to use their defaults instead.
 
-The default is zero for the low bound and the length of the slice for the high bound.
+The default is zero for the low bound and the length of the array for the high bound.
 
 For the array
 


### PR DESCRIPTION
Taking to Go lang tour, I've observed in the "slice defaults" section that the default high bound of a slice is defined as the length of the slice, not the length of the array.

Line 141 in "content/moretypes.article" was modified, replacing "slice" with "array".