### PR TITLE
Fix: Correct a typo where fmt.Printf was confused with fmt.Print.

### DIFF
--- a/content/methods.article
+++ b/content/methods.article
@@ -208,7 +208,7 @@ An empty interface may hold values of any type.
 (Every type implements at least zero methods.)
 
 Empty interfaces are used by code that handles values of unknown type.
-For example, `fmt.Print` takes any number of arguments of type `interface{}`.
+For example, `fmt.Printf` takes any number of arguments of type `interface{}`.
 
 .play methods/empty-interface.go
 


### PR DESCRIPTION
1. Why is this change neccesary?
Because in the exercise what we want to show the student is a value and it's
data type using an interface, this can be achieved with `fmt.Printf` since it
formats our output and shows the value and data type used to store it however,
the tutorial has `fmt.Print` which doesn't format our output and gives something
different than what we expect.

This is the output for `fmt.Printf`:

```
(<nil>, <nil>)
(42, int)
(hello, string)
```

This is the output for `fmt.Print`:

```
(%v, %T)
<nil> <nil>(%v, %T)
42 42(%v, %T)
hellohello
```

2. How does it address the issue?
`fmt.Print` was replaced by `fmt.Printf`.

3. What side effects does this change have?
Closes #768