### PR TITLE
Fix execution result of the sample code mathematically natural.

### DIFF
--- a/content/moretypes/range.go
+++ b/content/moretypes/range.go
@@ -4,7 +4,7 @@ package main
 
 import "fmt"
 
-var pow = []int{1, 2, 4, 8, 16, 32, 64, 128}
+var pow = []int{0, 2, 4, 8, 16, 32, 64, 128}
 
 func main() {
 	for i, v := range pow {


### PR DESCRIPTION
fix sample code so that the execution result of Tour https://tour.golang.org/moretypes/16 becomes mathematically natural.


# result
## Before

```
2**0 = 1
2**1 = 2
2**2 = 4
2**3 = 8
2**4 = 16
2**5 = 32
2**6 = 64
2**7 = 128
```

I think that `2 ** 0 = 1` is mathematically unnatural.

## After
```
2**0 = 0
2**1 = 2
2**2 = 4
2**3 = 8
2**4 = 16
2**5 = 32
2**6 = 64
2**7 = 128
```

Don't you think that this is more natural?