### PR TITLE
tour: Rename mux -> mu to follow convention

### DIFF
--- a/content/concurrency/mutex-counter.go
+++ b/content/concurrency/mutex-counter.go
@@ -10,8 +10,8 @@ import (
 
 // SafeCounter is safe to use concurrently.
 type SafeCounter struct {
-	v  map[string]int
 	mu sync.Mutex
+	v  map[string]int
 }
 
 // Inc increments the counter for the given key.

--- a/content/concurrency/mutex-counter.go
+++ b/content/concurrency/mutex-counter.go
@@ -10,23 +10,23 @@ import (
 
 // SafeCounter is safe to use concurrently.
 type SafeCounter struct {
-	v   map[string]int
-	mux sync.Mutex
+	v  map[string]int
+	mu sync.Mutex
 }
 
 // Inc increments the counter for the given key.
 func (c *SafeCounter) Inc(key string) {
-	c.mux.Lock()
+	c.mu.Lock()
 	// Lock so only one goroutine at a time can access the map c.v.
 	c.v[key]++
-	c.mux.Unlock()
+	c.mu.Unlock()
 }
 
 // Value returns the current value of the counter for the given key.
 func (c *SafeCounter) Value(key string) int {
-	c.mux.Lock()
+	c.mu.Lock()
 	// Lock so only one goroutine at a time can access the map c.v.
-	defer c.mux.Unlock()
+	defer c.mu.Unlock()
 	return c.v[key]
 }
 


### PR DESCRIPTION
Nearly all sync.Mutex members in the standard library are named mu,
or use "mu" as part of the name. While this isn't a documented
recommendation anywhere that I can find, it would seem nice to start
new users with this same convention.