### PR TITLE
Clarify concurrency sending/receiving language

### DIFF
--- a/content/concurrency.article
+++ b/content/concurrency.article
@@ -47,7 +47,7 @@ Channels can be _buffered_.  Provide the buffer length as the second argument to
 
 	ch := make(chan int, 100)
 
-Sends to a buffered channel block only when the buffer is full. Receives block when the buffer is empty.
+Sending to a buffered channel only blocks when the buffer is full. Receiving blocks when the buffer is empty.
 
 Modify the example to overfill the buffer and see what happens.
 


### PR DESCRIPTION
In [Buffered Channels
](https://tour.golang.org/concurrency/3)

Editing
> Sends to a buffered channel block only when the buffer is full. Receives block when the buffer is empty.

Sends is usually a verb, as in "The person sends mail to the other person".
Block can be a noun or a verb.
Therefore, I initially understood the sentence, "Sends to a buffered channel block only when the buffer is full"
as  "\<Something> sends to a 'buffered channel block' [what's a channel block?] only when the buffer is full." or "\<Something> only sends to a buffered channel block when the buffer is full"
Therefore, I changed "Sends" to "sending", and moved "only" before "blocks"