### PR TITLE
Tour: A better demonstrative example for type conversions

### DIFF
--- a/content/basics/type-conversions.go
+++ b/content/basics/type-conversions.go
@@ -10,6 +10,7 @@ import (
 func main() {
 	var x, y int = 4, 5
 	var f float64 = math.Sqrt(float64(x*x + y*y))
+	fmt.Println(f)
 	var z uint = uint(f)
 	fmt.Println(x, y, z)
 }

--- a/content/basics/type-conversions.go
+++ b/content/basics/type-conversions.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var x, y int = 3, 4
+	var x, y int = 4, 5
 	var f float64 = math.Sqrt(float64(x*x + y*y))
 	var z uint = uint(f)
 	fmt.Println(x, y, z)


### PR DESCRIPTION
The current example calculates a hypotenuse for the legs 3 and 4 which
is exactly 5. Then the values of f and z visually (if printed) are both
5 which might be confusing, "what's the purpose of the conversion if we
could have printed the value of f directly?"

I propose to use such numbers so that the hypotenuse is not an integer
number to avoid the confusion and illustrate that the conversion did
happen and that the conversion drops the precision. The smallest two
different legs that have a hypotenuse which is neither an integer nor is
a duplicate of either of the legs, when converted to an integer, are 4
and 5 with the hypotenuse 6.4