### PR TITLE
tour: fix swapped width and height in images exercise solution

### DIFF
--- a/solutions/image.go
+++ b/solutions/image.go
@@ -22,7 +22,7 @@ func (m Image) ColorModel() color.Model {
 }
 
 func (m Image) Bounds() image.Rectangle {
-	return image.Rect(0, 0, m.Height, m.Width)
+	return image.Rect(0, 0, m.Width, m.Height)
 }
 
 func (m Image) At(x, y int) color.Color {


### PR DESCRIPTION
The current solution creates the image rect using the origin point (0, 0) and (Height, Width). Since the x-axis is horizontal and the y-axis is vertical, these arguments should be swapped.