### PR TITLE
Removing redundant brackets

### DIFF
--- a/content/flowcontrol.article
+++ b/content/flowcontrol.article
@@ -128,14 +128,14 @@ be constants, and the values involved need not be integers.
 
 Switch cases evaluate cases from top to bottom, stopping when a case succeeds.
 
-(For example,
+For example,
 
 	switch i {
 	case 0:
 	case f():
 	}
 
-does not call `f` if `i==0`.)
+does not call `f` if `i==0`.
 
 #appengine: *Note:* Time in the Go playground always appears to start at
 #appengine: 2009-11-10 23:00:00 UTC, a value whose significance is left as an


### PR DESCRIPTION
Removing redundant brackets in the article