### PR TITLE
tour: fix wrong arguments order for image.Rect

### DIFF
--- a/solutions/image.go
+++ b/solutions/image.go
@@ -22,7 +22,7 @@ func (m Image) ColorModel() color.Model {
 }
 
 func (m Image) Bounds() image.Rectangle {
-	return image.Rect(0, 0, m.Height, m.Width)
+	return image.Rect(0, 0, m.Width, m.Height)
 }
 
 func (m Image) At(x, y int) color.Color {
@@ -31,6 +31,6 @@ func (m Image) At(x, y int) color.Color {
 }
 
 func main() {
-	m := Image{256, 256}
+	m := Image{256, 512}
 	pic.ShowImage(m)
 }


### PR DESCRIPTION
Fix: https://github.com/golang/tour/issues/994