### PR TITLE
Fix editor layout height

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -386,6 +386,7 @@ a#run, a#kill {
     }
     #explorer + div {
         top: 32px;
+        height: calc(100% - 32px);
     }
     #file-menu {
         position: absolute;


### PR DESCRIPTION
Hey!

Right now the editor's part of the tour is shifted on 32px from top bottom due to this line:

https://github.com/golang/tour/blob/master/static/css/app.css#L388

At the same time, editor's height is set by `.relative-content` styles to 100% of it's parent container:

https://github.com/golang/tour/blob/master/static/css/app.css#L81
https://github.com/golang/tour/blob/master/static/partials/editor.html#L23

These facts lead to cutting away 32px from the bottom of the editor. Here's how long program output looks right now:

<img width="638" alt="Screen Shot 2020-07-27 at 00 42 37" src="https://user-images.githubusercontent.com/6537798/88490212-a221d800-cfa2-11ea-8491-e2955e054692.png">

You don't see “Program exited” and can't scroll to see it (the screenshot has been taken here: https://tour.golang.org/moretypes/8).

And here's how it will look in case of merging this PR:

<img width="638" alt="Screen Shot 2020-07-27 at 00 43 00" src="https://user-images.githubusercontent.com/6537798/88490237-cc739580-cfa2-11ea-8c92-9fd0285ff995.png">

It's possible to scroll to “Program exited” sign.