### PR TITLE
tour: Remove unnecessary 0 addition

### DIFF
--- a/content/flowcontrol/switch-evaluation-order.go
+++ b/content/flowcontrol/switch-evaluation-order.go
@@ -11,7 +11,7 @@ func main() {
 	fmt.Println("When's Saturday?")
 	today := time.Now().Weekday()
 	switch time.Saturday {
-	case today + 0:
+	case today:
 		fmt.Println("Today.")
 	case today + 1:
 		fmt.Println("Tomorrow.")


### PR DESCRIPTION
Hello!

I've removed `+ 0` from the https://tour.golang.org/flowcontrol/10 code example, because it was leading to confusion. It is not necessary there, and most likely was added to preserve alignment or for consistency.

There was a discussion about this expression in #1003.