### PR TITLE
[Fix] Wrapper: Improve scroll smoothly

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -58,12 +58,7 @@ code {
     user-select: none;
 }
 .wrapper {
-    position: fixed;
-    overflow: auto;
-    top: 48px;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    padding-top: 48px;
 }
 .container {
     max-width: 800px;


### PR DESCRIPTION
# Overview

I have seen the `position: fixed` in `.wrapper` and it makes the content can't scroll smoothly.
So, I remove the fixed position by `padding-top` for header.

# Scope of work

Remove position fixed and implement `padding-top`

If you have any feedbacks or suggestions, please do not hesitate to reply on this PR. 😎