### PR TITLE
tour: updated readme and welcome article page-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ https://tour.golang.org to start the tour.
 
 ## Download/Install
 
-To install the tour from source, first
-[install Go](https://golang.org/doc/install) and then run:
+To run the tour locally, you'll first need to install
+[Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and
+[Go](https://golang.org/doc/install) and then run:
 
 	$ go get golang.org/x/tour
 

--- a/content/welcome.article
+++ b/content/welcome.article
@@ -67,8 +67,9 @@ Click the [[javascript:highlightAndClick(".next-page")]["next"]] button or type 
 #appengine: without access to the internet. It builds and runs the code samples on
 #appengine: your own machine.
 #appengine:
-#appengine: To run the tour locally, you'll need to first
-#appengine: [[https://golang.org/doc/install][install Go]] and then run:
+#appengine: To run the tour locally, you'll first need to install
+#appengine: [[https://git-scm.com/book/en/v2/Getting-Started-Installing-Git][Git]] and
+#appengine: [[https://golang.org/doc/install][Go]] and then run:
 #appengine:
 #appengine:   go get golang.org/x/tour
 #appengine:


### PR DESCRIPTION
Existing documentation and article has only instructed to install go to use go/tour locally, new change instructs to first install both git and go.

Fixes golang/tour#1096