### PR TITLE
Simplify mutex counter, replacing map with int

### DIFF
--- a/content/concurrency/mutex-counter.go
+++ b/content/concurrency/mutex-counter.go
@@ -11,31 +11,33 @@ import (
 // SafeCounter is safe to use concurrently.
 type SafeCounter struct {
 	mu sync.Mutex
-	v  map[string]int
+	v  int
 }
 
-// Inc increments the counter for the given key.
-func (c *SafeCounter) Inc(key string) {
+// Inc increments the counter.
+func (c *SafeCounter) Inc() {
 	c.mu.Lock()
-	// Lock so only one goroutine at a time can access the map c.v.
-	c.v[key]++
+	// Lock so only one goroutine at a time can access the int c.v.
+	c.v++
 	c.mu.Unlock()
 }
 
-// Value returns the current value of the counter for the given key.
-func (c *SafeCounter) Value(key string) int {
+// Value returns the current value of the counter.
+func (c *SafeCounter) Value() int {
 	c.mu.Lock()
 	// Lock so only one goroutine at a time can access the map c.v.
 	defer c.mu.Unlock()
-	return c.v[key]
+	return c.v
 }
 
 func main() {
-	c := SafeCounter{v: make(map[string]int)}
+
+	c := SafeCounter{}
 	for i := 0; i < 1000; i++ {
-		go c.Inc("somekey")
+		go c.Inc()
 	}
 
 	time.Sleep(time.Second)
-	fmt.Println(c.Value("somekey"))
+	fmt.Println(c.Value())
 }
+

--- a/content/concurrency/mutex-counter.go
+++ b/content/concurrency/mutex-counter.go
@@ -31,7 +31,6 @@ func (c *SafeCounter) Value() int {
 }
 
 func main() {
-
 	c := SafeCounter{}
 	for i := 0; i < 1000; i++ {
 		go c.Inc()


### PR DESCRIPTION
The map added complexity for no benefit. We only need an int to illustrate the mutex here.

I understand from comments on https://github.com/golang/tour/issues/35 and other issues that:
> they're being scheduled over a single thread (a constraint of the playground sandbox)

So I ran mutex-counter.go locally to see how and when the mutex was needed. I found:
- Running the code (looping 100 times) as per this PR without a mutex gave a final result of 963 or 911, without crashing.
- Running the original code with the `map` present crashed the program with `fatal error: concurrent map writes`. This crash would occur on my machine even when looping only 45 times.

(My machine is a 2021 MBP, M1 chip)

I think a result of 911 is equally good an illustration as a fatal error here, but I think a simpler code example is better for people learning this concept.