### PR TITLE
tour: updated description for `if` statement in flowcontrol article

### DIFF
--- a/content/flowcontrol.article
+++ b/content/flowcontrol.article
@@ -46,8 +46,8 @@ If you omit the loop condition it loops forever, so an infinite loop is compactl
 
 * If
 
-Go's `if` statements are like its `for` loops; the expression need not be
-surrounded by parentheses `(`)` but the braces `{`}` are required.
+The expression does not need to be surrounded by parentheses `(`)` in Go's `if` statement and 
+the braces `{`}` are always required.
 
 .play flowcontrol/if.go
 


### PR DESCRIPTION
Existing article is misleading, in new change clear description is provided

Fixes golang/tour#743