### PR TITLE
tour: Specify Version 1.18 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module golang.org/x/tour
 
-go 1.16
+go 1.18


### PR DESCRIPTION
When running the tour locally with default settings, the "Type parameters" example at http://127.0.0.1:3999/tour/generics/1 fails with the following error:
`type parameter requires go1.18 or later (-lang was set to go1.16; check go.mod)`

...even when running on 1.18+

I think updating the runtime version declaration here should fix that.

I'm not sure if this should be bumped to 1.19 or not, but feel free to set it such if desired.